### PR TITLE
Rename generateThumbnails(number) to getThumbnails(number) for more continuity

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ generator.getThumbnail()
 You can also generate multiple thumbnails at once:
 
 ```
-  generator.getThumbnails(5)
+  generator.generateThumbnails(5)
   .then((thumbnails) => {
     // Use the thumbnails...
     console.log(thumbnails);

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ generator.getThumbnail()
 You can also generate multiple thumbnails at once:
 
 ```
-  generator.generateThumbnails(5)
+  generator.getThumbnails(5)
   .then((thumbnails) => {
     // Use the thumbnails...
     console.log(thumbnails);

--- a/src/components/browser-video-convert-example/browser-video-convert-example.tsx
+++ b/src/components/browser-video-convert-example/browser-video-convert-example.tsx
@@ -23,7 +23,7 @@ export class BrowserVideoConvertExample implements ComponentInterface {
     //create Thumbnail on position
     this.convert = new VideoThumbnailGenerator(this.objectURL) as VideoThumbnailGenerator;
     this.generatedImg = await this.convert.getThumbnail(this.framePosition);
-    this.generatedImgs = await this.convert.generateThumbnails(5);
+    this.generatedImgs = await this.convert.getThumbnails(5);
 
     //cleanup
     URL.revokeObjectURL(this.objectURL as string);
@@ -47,7 +47,7 @@ export class BrowserVideoConvertExample implements ComponentInterface {
           }
         </ul>
         <ul>
-          <li>generateThumbnails</li>
+          <li>getThumbnails</li>
           {this.generatedImgs && this.generatedImgs.map((img) =>
             <li><img width={200} alt='test test' src={img.thumbnail} /></li>,
           )}

--- a/src/libs/videoThumbnailGenerator.ts
+++ b/src/libs/videoThumbnailGenerator.ts
@@ -69,7 +69,7 @@ export class VideoThumbnailGenerator {
     this.video.addEventListener('error', onError);
   }
 
-  public async generateThumbnails(numFrames: number): Promise<{ width: number, height: number, thumbnail: string }[]> {
+  public async getThumbnails(numFrames: number): Promise<{ width: number, height: number, thumbnail: string }[]> {
     this.initVideo();
     await new Promise((resolve, reject) => this.addListener(resolve, reject));
     const thumbnails = [];


### PR DESCRIPTION
I was trying to use this package from npm and the docs said that the function used for generating multiple thumbnails was called getThumbnails(number), but that threw a typescript error. I looked in the declarations file, and it turned out that it was actually called generateThumbnails(number). I figured that I would first just update the docs, but then decided to rather update the function to add continuity so there would be getThumbnail() and getThumbnails(number). I think I changed every instance in the code, but please double check. 

Thanks for this package!